### PR TITLE
docker: ship Dockerfile + GHCR publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+**/node_modules
+**/dist
+**/.vscode
+**/.idea
+data/
+*.db
+README.md
+LICENSE
+scripts/
+uwp/
+backend/data/
+backend/bin/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,47 @@
+name: Build and publish Docker image
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+  packages: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/unrealircd-webpanel-2
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Build (and push when not PR)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:22-alpine AS frontend
+WORKDIR /src/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ ./
+RUN npm run build
+
+FROM golang:1.25-alpine AS backend
+WORKDIR /src
+RUN apk add --no-cache git
+COPY backend/go.mod backend/go.sum ./backend/
+RUN cd backend && go mod download
+COPY backend/ ./backend/
+RUN cd backend && CGO_ENABLED=0 GOOS=linux \
+    go build -ldflags="-s -w" -o /out/webpanel ./cmd/server
+
+FROM alpine:3.21
+RUN apk add --no-cache ca-certificates tzdata \
+ && addgroup -S panel && adduser -S -G panel panel
+WORKDIR /app
+COPY --from=backend  /out/webpanel        ./webpanel
+COPY --from=frontend /src/frontend/dist   ./frontend
+COPY config.example.json                  ./config.example.json
+RUN mkdir -p /app/data && chown -R panel:panel /app
+USER panel
+EXPOSE 8080
+VOLUME ["/app/data"]
+ENTRYPOINT ["./webpanel"]


### PR DESCRIPTION
Multi-stage Dockerfile (Vite frontend + static Go binary, alpine runtime) and a workflow that publishes ghcr.io/<owner>/unrealircd-webpanel-2 on every push to main.